### PR TITLE
Add patch that fixes flickering when resizing child windows on WineD3D

### DIFF
--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -32,6 +32,7 @@ jobs:
         
         wine-staging/staging/patchinstall.py --destdir=wine fonts-Missing_Fonts
         patch -d wine -sNp1 < 0001-revert-win32u-Update-client-surfaces-starting-from-toplevel.patch
+        patch -d wine -sNp1 < 0001-win32u-Avoid-a-crash-when-drawable-fails-to-be-creat.patch
         patch -d wine -sNp1 < dont-load-bitmap-only-ttf-fonts.patch
         patch -d wine -sNp1 < xfixes-hide-cursor.patch
         patch -d wine -sNp1 < fix-winecfg-audio-crash.patch

--- a/0001-win32u-Avoid-a-crash-when-drawable-fails-to-be-creat.patch
+++ b/0001-win32u-Avoid-a-crash-when-drawable-fails-to-be-creat.patch
@@ -1,0 +1,76 @@
+From e712c4a8cd198f5a7a3c8318048f5368b5a49098 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Mon, 1 Dec 2025 18:48:28 +0100
+Subject: [PATCH 1/2] win32u: Avoid a crash when drawable fails to be created.
+
+---
+ dlls/win32u/opengl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/win32u/opengl.c b/dlls/win32u/opengl.c
+index 57a0c773cbc..8fdc7deaf2f 100644
+--- a/dlls/win32u/opengl.c
++++ b/dlls/win32u/opengl.c
+@@ -1656,7 +1656,7 @@ static BOOL context_sync_drawables( struct wgl_context *context, HDC draw_hdc, H
+     if (draw_hdc && !context->draw) context->draw = get_dc_opengl_drawable( draw_hdc );
+     if (read_hdc && !context->read) context->read = get_dc_opengl_drawable( read_hdc );
+ 
+-    new_draw = get_updated_drawable( draw_hdc, context->format, context->draw );
++    if (!(new_draw = get_updated_drawable( draw_hdc, context->format, context->draw ))) return FALSE;
+     if (!draw_hdc && context->draw == context->read) opengl_drawable_add_ref( (new_read = new_draw) );
+     else if (draw_hdc && draw_hdc == read_hdc) opengl_drawable_add_ref( (new_read = new_draw) );
+     else new_read = get_updated_drawable( read_hdc, context->format, context->read );
+-- 
+2.52.0
+
+
+From 318fba6b160ee20535e6a03e2aa606ba7ff32f36 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Mon, 1 Dec 2025 18:41:22 +0100
+Subject: [PATCH 2/2] win32u: Check internal drawables before trying to create new
+ ones.
+
+---
+ dlls/win32u/opengl.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/dlls/win32u/opengl.c b/dlls/win32u/opengl.c
+index 8fdc7deaf2f..70744889d02 100644
+--- a/dlls/win32u/opengl.c
++++ b/dlls/win32u/opengl.c
+@@ -1631,17 +1631,21 @@ static struct opengl_drawable *get_updated_drawable( HDC hdc, int format, struct
+ {
+     HWND hwnd = NULL;
+ 
++    /* return the memory DCs drawables directly */
+     if (hdc && !(hwnd = NtUserWindowFromDC( hdc ))) return get_dc_opengl_drawable( hdc );
+     if (!hdc && drawable && drawable->client) hwnd = drawable->client->hwnd;
+     if (!hwnd) return NULL;
+ 
+-    /* if the window still has a drawable, keep using the one we have */
++    /* if the drawable we were using is for the same window, keep using it */
+     if (drawable && is_client_surface_window( drawable->client, hwnd ))
+     {
+         opengl_drawable_add_ref( drawable );
+         return drawable;
+     }
+ 
++    /* retrieve D3D internal drawables from the DCs if they have any */
++    if (hdc && (drawable = get_dc_opengl_drawable( hdc ))) return drawable;
++
+     /* get an updated drawable with the desired format */
+     return get_window_unused_drawable( hwnd, format );
+ }
+@@ -1652,10 +1656,6 @@ static BOOL context_sync_drawables( struct wgl_context *context, HDC draw_hdc, H
+     struct wgl_context *previous = NtCurrentTeb()->glContext;
+     BOOL ret = FALSE;
+ 
+-    /* retrieve the D3D internal drawables from the DCs if they have any */
+-    if (draw_hdc && !context->draw) context->draw = get_dc_opengl_drawable( draw_hdc );
+-    if (read_hdc && !context->read) context->read = get_dc_opengl_drawable( read_hdc );
+-
+     if (!(new_draw = get_updated_drawable( draw_hdc, context->format, context->draw ))) return FALSE;
+     if (!draw_hdc && context->draw == context->read) opengl_drawable_add_ref( (new_read = new_draw) );
+     else if (draw_hdc && draw_hdc == read_hdc) opengl_drawable_add_ref( (new_read = new_draw) );
+-- 
+2.52.0


### PR DESCRIPTION
There was a regression with Wine 10.20 that resulted in WineD3D to cause flickering when resizing child windows in Roblox Studio. This patch addresses this.